### PR TITLE
基本的なモデルを追加

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -10,7 +10,7 @@ gem "puma", ">= 5.0"
 # gem "jbuilder"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
-# gem "bcrypt", "~> 3.1.7"
+gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       uri (>= 0.13.1)
     ast (2.4.3)
     base64 (0.3.0)
+    bcrypt (3.1.20)
     bcrypt_pbkdf (1.1.1)
     bcrypt_pbkdf (1.1.1-arm64-darwin)
     bcrypt_pbkdf (1.1.1-x86_64-darwin)
@@ -328,6 +329,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  bcrypt (~> 3.1.7)
   bootsnap
   brakeman
   debug

--- a/backend/app/models/account.rb
+++ b/backend/app/models/account.rb
@@ -1,0 +1,13 @@
+# ==============================================
+# ユーザーのグループアカウントを管理するモデル
+# ==============================================
+class Account < ApplicationRecord
+  belongs_to :owner, class_name: "User"
+
+  has_many :members, dependent: :destroy
+  has_many :users, through: :members
+  has_many :expenses, dependent: :destroy
+  has_many :incomes, dependent: :destroy
+
+  validates :name, presence: true
+end

--- a/backend/app/models/expense.rb
+++ b/backend/app/models/expense.rb
@@ -1,0 +1,12 @@
+# ==============================================
+# 支出を管理するモデル
+# ==============================================
+class Expense < ApplicationRecord
+  belongs_to :account
+  belongs_to :user
+
+  validates :category, :amount, :spent_on, presence: true
+  validates :amount, numericality: { greater_than: 0 }
+
+  scope :for_month, ->(date) { where(spent_on: date.beginning_of_month..date.end_of_month) }
+end

--- a/backend/app/models/income.rb
+++ b/backend/app/models/income.rb
@@ -1,0 +1,12 @@
+# ==============================================
+# 収入を管理するモデル
+# ==============================================
+class Income < ApplicationRecord
+  belongs_to :account
+  belongs_to :user
+
+  validates :category, :amount, :received_on, presence: true
+  validates :amount, numericality: { greater_than: 0 }
+
+  scope :for_month, ->(date) { where(received_on: date.beginning_of_month..date.end_of_month) }
+end

--- a/backend/app/models/member.rb
+++ b/backend/app/models/member.rb
@@ -1,0 +1,10 @@
+# ==============================================
+# アカウントに所属するメンバーを管理するモデル
+# ==============================================
+class Member < ApplicationRecord
+  belongs_to :account
+  belongs_to :user
+
+  validates :role, inclusion: { in: %w[owner member] }
+  validates :user_id, uniqueness: { scope: :account_id }
+end

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,0 +1,15 @@
+# ==============================================
+# ユーザーを管理するモデル
+# ==============================================
+class User < ApplicationRecord
+  has_secure_password
+
+  has_many :accounts, foreign_key: :owner_id, inverse_of: :owner, dependent: :destroy
+  has_many :members, dependent: :destroy
+  has_many :joined_accounts, through: :members, source: :account
+  has_many :expenses, through: :accounts
+  has_many :incomes, through: :accounts
+
+  validates :email, presence: true, uniqueness: true
+  validates :name, presence: true
+end

--- a/backend/db/migrate/20251101090000_create_users.rb
+++ b/backend/db/migrate/20251101090000_create_users.rb
@@ -1,0 +1,13 @@
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users, comment: "ユーザー" do |t|
+      t.string :name, null: false, comment: "名前"
+      t.string :email, null: false, comment: "メールアドレス"
+      t.string :password_digest, null: false, comment: "パスワードハッシュ"
+
+      t.timestamps
+    end
+
+    add_index :users, :email, unique: true
+  end
+end

--- a/backend/db/migrate/20251101090100_create_accounts.rb
+++ b/backend/db/migrate/20251101090100_create_accounts.rb
@@ -1,0 +1,10 @@
+class CreateAccounts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :accounts, comment: "ユーザーのグループアカウント" do |t|
+      t.string :name, null: false, comment: "アカウント名"
+      t.references :owner, null: false, foreign_key: { to_table: :users }, comment: "オーナー"
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20251101090200_create_members.rb
+++ b/backend/db/migrate/20251101090200_create_members.rb
@@ -1,0 +1,13 @@
+class CreateMembers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :members, comment: "ユーザーのグループアカウントに所属するメンバー" do |t|
+      t.references :account, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+      t.string :role, null: false, default: "member", comment: "ロール"
+
+      t.timestamps
+    end
+
+    add_index :members, [:account_id, :user_id], unique: true
+  end
+end

--- a/backend/db/migrate/20251101090300_create_expenses.rb
+++ b/backend/db/migrate/20251101090300_create_expenses.rb
@@ -1,0 +1,14 @@
+class CreateExpenses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :expenses, comment: "支出" do |t|
+      t.references :account, null: false, foreign_key: true, comment: "アカウント"
+      t.references :user, null: false, foreign_key: true, comment: "ユーザー"
+      t.string :category, null: false, comment: "カテゴリ"
+      t.integer :amount, null: false, comment: "金額"
+      t.date :spent_on, null: false, comment: "支出日"
+      t.text :memo, comment: "メモ"
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20251101090400_create_incomes.rb
+++ b/backend/db/migrate/20251101090400_create_incomes.rb
@@ -1,0 +1,14 @@
+class CreateIncomes < ActiveRecord::Migration[8.0]
+  def change
+    create_table :incomes, comment: "収入" do |t|
+      t.references :account, null: false, foreign_key: true, comment: "アカウント"
+      t.references :user, null: false, foreign_key: true, comment: "ユーザー"
+      t.string :category, null: false, comment: "カテゴリ"
+      t.integer :amount, null: false, comment: "金額"
+      t.date :received_on, null: false, comment: "収入日"
+      t.text :memo, comment: "メモ"
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,5 +10,66 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 0) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_01_090400) do
+  create_table "accounts", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "ユーザーのグループアカウント", force: :cascade do |t|
+    t.string "name", null: false, comment: "アカウント名"
+    t.bigint "owner_id", null: false, comment: "オーナー"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["owner_id"], name: "index_accounts_on_owner_id"
+  end
+
+  create_table "expenses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "user_id", null: false
+    t.string "category", null: false
+    t.integer "amount", null: false
+    t.date "spent_on", null: false
+    t.text "memo"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_expenses_on_account_id"
+    t.index ["user_id"], name: "index_expenses_on_user_id"
+  end
+
+  create_table "incomes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "収入", force: :cascade do |t|
+    t.bigint "account_id", null: false, comment: "アカウント"
+    t.bigint "user_id", null: false, comment: "ユーザー"
+    t.string "category", null: false, comment: "カテゴリ"
+    t.integer "amount", null: false, comment: "金額"
+    t.date "received_on", null: false, comment: "収入日"
+    t.text "memo", comment: "メモ"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id"], name: "index_incomes_on_account_id"
+    t.index ["user_id"], name: "index_incomes_on_user_id"
+  end
+
+  create_table "members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "ユーザーのグループアカウントに所属するメンバー", force: :cascade do |t|
+    t.bigint "account_id", null: false
+    t.bigint "user_id", null: false
+    t.string "role", default: "member", null: false, comment: "ロール"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["account_id", "user_id"], name: "index_members_on_account_id_and_user_id", unique: true
+    t.index ["account_id"], name: "index_members_on_account_id"
+    t.index ["user_id"], name: "index_members_on_user_id"
+  end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", comment: "ユーザー", force: :cascade do |t|
+    t.string "name", null: false, comment: "名前"
+    t.string "email", null: false, comment: "メールアドレス"
+    t.string "password_digest", null: false, comment: "パスワードハッシュ"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+  end
+
+  add_foreign_key "accounts", "users", column: "owner_id"
+  add_foreign_key "expenses", "accounts"
+  add_foreign_key "expenses", "users"
+  add_foreign_key "incomes", "accounts"
+  add_foreign_key "incomes", "users"
+  add_foreign_key "members", "accounts"
+  add_foreign_key "members", "users"
 end


### PR DESCRIPTION
## ブランチ概要: feat/add-base-model
**目的**: ProsperSyncアプリの基盤モデルとデータベーススキーマを実装
**主な変更**:
- `bcrypt` gemを追加（パスワード管理用）
- 基本モデル5つを作成：
  - `User` - ユーザー（パスワード認証）
  - `Account` - グループアカウント
  - `Member` - アカウントメンバー（多対多）
  - `Expense` - 支出
  - `Income` - 収入
- 各モデルに対応するマイグレーションを追加
- モデル間の関連とバリデーションを実装
**実装内容**:
- パスワード管理: `has_secure_password`を使用
- 関連付け: User ↔ Account ↔ Member ↔ Expense/Income
- バリデーション: 必須項目、ユニーク制約、数値検証
- スコープ: 月別検索（Expense/Income）